### PR TITLE
Workshop cleanup

### DIFF
--- a/content/01_Getting_Started/01_the_tools.md
+++ b/content/01_Getting_Started/01_the_tools.md
@@ -15,7 +15,7 @@ In terms of understanding git for this workshop, dbt Cloud will guide you throug
 <script src="https://fast.wistia.com/embed/medias/6gc3ojy45n.jsonp" async></script><script src="https://fast.wistia.com/assets/external/E-v1.js" async></script><div class="wistia_responsive_padding" style="padding:73.33% 0 0 0;position:relative;"><div class="wistia_responsive_wrapper" style="height:100%;left:0;position:absolute;top:0;width:100%;"><div class="wistia_embed wistia_async_6gc3ojy45n videoFoam=true" style="height:100%;position:relative;width:100%"><div class="wistia_swatch" style="height:100%;left:0;opacity:0;overflow:hidden;position:absolute;top:0;transition:opacity 200ms;width:100%;"><img src="https://fast.wistia.com/embed/medias/6gc3ojy45n/swatch" style="filter:blur(5px);height:100%;object-fit:contain;width:100%;" alt="" aria-hidden="true" onload="this.parentNode.style.opacity=1;" /></div></div></div></div>
 
 *Summary of this video:*
-- We will be using Redshift as our Data Warehouse to compute and storage our transformations. We will be using the Spectrum feature to query from S3. 
+- We will be using Redshift as our Data Warehouse to compute and store our transformations. We will be using the Spectrum feature to query from S3. 
 - Our S3 bucket is our object storage. It's great for storing large amounts of data. 
 - Github will be our version control/git provider. It will be our code storage and code change management system.
 
@@ -30,7 +30,7 @@ In terms of understanding git for this workshop, dbt Cloud will guide you throug
 - Using dbt's ref function and ability to write DDL and DML, you can create repeatable builds and promote through environments without having to change the code. The ref function also builds dependencies automatically so you can focus on modeling, not run order or having to manually create the DAG via a third party tool.
 - dbt docs compiles the information you supply dbt via the project and the data warehouse information schema to a sharable documentation site that you can use for yourself and stakeholderse. Documentation also can automatically display lineage from raw objects to transformation to third party dependencies.
 - dbt Tests are all written in SQL and can be used to validate your data assumptions. 
-- By using dbt, you can provide a version control and CI/CD workflow to another comfortable with SQL.
+- By using dbt, you can provide a version control and CI/CD workflow to anyone comfortable with SQL.
 
 
 

--- a/content/03_Development/01_stage_raw.md
+++ b/content/03_Development/01_stage_raw.md
@@ -19,8 +19,12 @@ In this video, we will demostrate how to install a package and then use the pack
 ```yml 
 packages:
    - package: dbt-labs/dbt_external_tables
-      version: 0.7.0
+      version: 0.8.0
+   - package: dbt-labs/dbt_utils
+      version: 0.8.1  
 ```
+
+The video mentions that installing the `dbt_external_tables` package will also install the `dbt_utils` package because it is used as a dependency. While this was true in previous versions, the updated version being used now does not perform the same auto-install. It's important to include the `dbt_utils` package as shown above when creating your `packages.yml` file to avoid errors when creating your external tables in step 11.
 4. Run `dbt deps` to install the package. A way to remember this command is deps = dependencies. 
 5. Create a `staging` folder in the `models` folder. 
 6. Create a folder named `tpch` inside of the `staging` folder.
@@ -42,7 +46,7 @@ version: 2
                 
           - name: lineitem
             external:
-                location: "s3://dbt-data-lake-[Insert AWS Account ID]]/dbtworkshopdata/lineitem/lineitem" 
+                location: "s3://dbt-data-lake-[Insert AWS Account ID]]/dbtworkshopdata/lineitem/" 
                 row_format: serde 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
                 table_properties: "('skip.header.line.count'='1')"
             columns:
@@ -78,7 +82,7 @@ version: 2
          
           - name: orders
             external:
-                location: "s3://dbt-data-lake-[Insert AWS Account ID]/dbtworkshopdata/orders/orders"      
+                location: "s3://dbt-data-lake-[Insert AWS Account ID]/dbtworkshopdata/orders/"      
                 row_format: serde 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
                 table_properties: "('skip.header.line.count'='1')"
             columns:

--- a/content/_index.md
+++ b/content/_index.md
@@ -9,7 +9,7 @@ weight: 1
 ### Welcome
 
 The format of this workshop will consist of trainings videos with helpful 
-code snippets and tips related to the workshop. Be sure to pay attention to pay attention to the text along 
+code snippets and tips related to the workshop. Be sure to pay attention to the text along 
 with the video. There are also related videos linked in the video for you to learn more 
 or cover any potential confusions.
 


### PR DESCRIPTION
Contains a number of changes:

- Fixing typos/repeated words
- updating package versions
- adding in a new package to be used in the workshop. `dbt_utils` used to be installed automatically because it is a dependency of `dbt_external_tables`, but that has changed in updated versions. The update reflects this and provides an explanation to people doing the workshop now.